### PR TITLE
s_xor function to c11 standard

### DIFF
--- a/backdoors/hacking.h
+++ b/backdoors/hacking.h
@@ -163,5 +163,6 @@ void reverse_shell(char *host, int port){
 }
 
 void s_xor(char *arg, int key, int nbytes) {
-	for(int i = 0; i < nbytes; i++) arg[i] ^= key;
+	int i;
+	for(i = 0; i < nbytes; i++) arg[i] ^= key;
 }


### PR DESCRIPTION
this change is neccecery because of new c11 standard. otherwise when there will be compile error:

```
In file included from heavens_door.c:27:0:
hacking.h: In function ‘s_xor’:
hacking.h:166:2: error: ‘for’ loop initial declarations are only allowed in C99 mode
  for(int i = 0; i < nbytes; i++) arg[i] ^= key;
  ^
hacking.h:166:2: note: use option -std=c99 or -std=gnu99 to compile your code
```

(gcc 4.8.5 20150623 (Red Hat 4.8.5-16))