### PR TITLE
Fix memory leaks on failure

### DIFF
--- a/userland/client/client.c
+++ b/userland/client/client.c
@@ -492,8 +492,9 @@ char *read_line(void)
 
 		if (position >= bufsize) {
 			bufsize += RL_BUFSIZE;
-			buffer = realloc(buffer, bufsize);
-			if (!buffer) {
+			char *buffer_backup = buffer;
+			if ((buffer = realloc(buffer, bufsize)) == NULL) {
+				free(buffer_backup);
 				fprintf(stderr, "reptile: allocation error\n");
 				exit(EXIT_FAILURE);
 			}

--- a/userland/client/listener.c
+++ b/userland/client/listener.c
@@ -223,13 +223,13 @@ int shell(int sock, char **args)
 		while (args[len] != NULL) {
 			size++;
 			size += strlen(args[len]);
-			temp = (char *)realloc(temp, size);
+			char *temp_backup = temp;
+			if ((temp = realloc(temp, size)) == NULL) {
+				free(temp_backup);
+				p_error("realloc");
+				return 1;
+			}
 			len++;
-		}
-
-		if (temp == NULL) {
-			p_error("realloc");
-			return 1;
 		}
 
 		memset(temp, '\0', size);
@@ -614,8 +614,9 @@ char *read_line(void)
 
 		if (position >= bufsize) {
 			bufsize += RL_BUFSIZE;
-			buffer = realloc(buffer, bufsize);
-			if (!buffer) {
+			char *buffer_backup = buffer;
+			if ((buffer = realloc(buffer, bufsize)) == NULL) {
+				free(buffer_backup);
 				fprintf(stderr, "reptile: allocation error\n");
 				exit(EXIT_FAILURE);
 			}

--- a/userland/shell.c
+++ b/userland/shell.c
@@ -163,8 +163,10 @@ int runshell(int client)
 
 	pid = fork();
 
-	if (pid < 0)
+	if (pid < 0) {
+		free(temp);
 		return (ERROR);
+	}
 
 	if (pid == 0) {
 		close(client);


### PR DESCRIPTION
- in `userland/client/listener.c` is a memory leak in `shell(int sock, char **args)` when a large amount of arguments is submitted, it is fixed in a similar way like this:
https://github.com/f0rb1dd3n/Reptile/blob/6bd476e38ebc15a5bd08a3457f14cf329978cad6/userland/client/client.c#L522-L528
- in `userland/client/client.c` and `userland/client/listener.c` is also a realloc memory leak in `readline(void)`
- in ` userland/shell.c` is a memory leak in `runshell(int client)` when `fork()` failed