### PR TITLE
Remove -fomit-frame-pointer in Kbuild

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -3,7 +3,7 @@ CONFIG_FILE                         := $(src)/../.config
 
 include $(CONFIG_FILE)
 
-ccflags-y	                        += -I$(src)/include -Werror -fno-stack-protector -fomit-frame-pointer
+ccflags-y	                        += -I$(src)/include -Werror -fno-stack-protector
 ldflags-y	                        += -T$(src)/khook/engine.lds
 
 obj-m		                        += $(MODNAME).o


### PR DESCRIPTION
When kernel built with CONFIG_HARDENED_USERCOPY=y (like CentOS 7),
check_stack_size will use frame point to check whether the kernel buffer
in copy_from/to_user is on stack or not. If Reptile is built without
frame pointer, check_stack_size with reach BAD_STACK case, which results
in BUG()